### PR TITLE
ENH v18.1.0 needs pytest 3.6.4 to build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - pep8-naming
         - ws4py
         - py
-        - pytest >=4,<5.0.0a0
+        - pytest =3.6.4
         - execnet
         - pytest-forked
         - pytest-xdist
@@ -137,7 +137,7 @@ outputs:
         - pep8-naming
         - ws4py
         - py
-        - pytest >=4,<5.0.0a0
+        - pytest =3.6.4
         - execnet
         - pytest-forked
         - pytest-xdist


### PR DESCRIPTION
This PR fixes the v18.1 build.