### PR TITLE
ENH more remaps; build tool isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ downstream builds easier.
     - `python_future`
     - `sqlalchemy`
     - `galsim`
+    - `pytest-session2file`
 
   I used the `manifest.remap` feature of `eups` to make sure this works with the
   existing stack installation routine. Many thanks to Jim Bosch for pointing out this

--- a/recipe/build_impl.sh
+++ b/recipe/build_impl.sh
@@ -295,6 +295,9 @@ compgen -G "${EUPS_PATH}/*/*/*/doc/xml/*" | xargs rm -rf
 compgen -G "${EUPS_PATH}/*/*/*/share/doc/*" | xargs rm -rf
 compgen -G "${EUPS_PATH}/*/*/*/share/man/*" | xargs rm -rf
 
+# remove the global tags file since it tends to leak across envs
+rm -f ${LSST_HOME}/stack/miniconda/ups_db/global.tags
+
 unset EUPS_DIR
 unset EUPS_PKGROOT
 unset -f setup

--- a/recipe/build_impl.sh
+++ b/recipe/build_impl.sh
@@ -255,7 +255,7 @@ source ${RECIPE_DIR}/remaps/galsim_remap.sh
 # ditto for a bunch of python stuff
 for pynm in python_psutil pep8_naming ws4py python_py python_execnet pytest pytest_forked \
             pytest_xdist python_coverage pytest_cov pyflakes pycodestyle python_mccabe flake8 \
-            pytest_flake8 esutil requests mpi4py python_future sqlalchemy; do
+            pytest_flake8 esutil requests mpi4py python_future sqlalchemy pytest_session2file; do
     source ${RECIPE_DIR}/remaps/generic_python_remap.sh $pynm
 done
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ package:
 build:
   skip: True  # [win or py < 37]
   number: 1
+  merge_build_host: True
 
 outputs:
   - name: stackvana-core
@@ -163,7 +164,7 @@ outputs:
         - pytest-runner
         - flake8-polyfill
 
-        # extra dep needed for the sims build
+        # needed for build of sims_* tags
         - cython
 
         # compilers for compiling

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - pep8-naming
         - ws4py
         - py
-        - pytest >=4,<5.0.0a0
+        - pytest >=4,<5.0.0a0|==3.6.4
         - execnet
         - pytest-forked
         - pytest-xdist
@@ -138,7 +138,7 @@ outputs:
         - pep8-naming
         - ws4py
         - py
-        - pytest >=4,<5.0.0a0
+        - pytest >=4,<5.0.0a0|==3.6.4
         - execnet
         - pytest-forked
         - pytest-xdist

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,6 +83,7 @@ outputs:
         - sqlalchemy
         - future
         - galsim ==2.2.2
+        - pytest-session2file
 
         # and these are needed for the build of sconsUtils
         - setuptools_scm
@@ -154,12 +155,16 @@ outputs:
         - sqlalchemy
         - future
         - {{ pin_compatible('galsim', max_pin='x.x.x') }}
+        - pytest-session2file
 
         # stuff added outside of the main LSST DM conda envs
         - setuptools_scm
         - apipkg
         - pytest-runner
         - flake8-polyfill
+
+        # extra dep needed for the sims build
+        - cython
 
         # compilers for compiling
         - c-compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ package:
 
 build:
   skip: True  # [win or py < 37]
-  number: 0
+  number: 1
 
 outputs:
   - name: stackvana-core

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -110,16 +110,16 @@ popd
 
 ###################################################
 # 5. Declare a new scons(Utils).
-echo "
+echo '
 setupRequired(python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
-" > ${LSST_HOME}/stackvana_scons/ups/scons.table
+' > ${LSST_HOME}/stackvana_scons/ups/scons.table
 
 eups declare \
     -m ${LSST_HOME}/stackvana_scons/ups/scons.table \
     -r ${LSST_HOME}/stackvana_scons scons "stackvana_scons_${LSST_TAG}"
 
-echo "
+echo '
 # -*- python -*-
 
 from lsst.sconsUtils import Configuration
@@ -127,9 +127,9 @@ from lsst.sconsUtils import Configuration
 dependencies = {}
 
 config = Configuration(__file__, libs=[], hasSwigFiles=False)
-" > ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg
+' > ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg
 
-echo "
+echo '
 setupRequired(scons)
 setupRequired(pytest_flake8)
 setupRequired(pep8_naming)
@@ -137,7 +137,7 @@ setupRequired(pytest_session2file)
 setupOptional(doxygen)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
-" > ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table
+' > ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table
 
 eups declare \
     -m ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table \

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -117,7 +117,7 @@ envPrepend(PATH, ${PRODUCT_DIR}/bin)
 
 eups declare \
     -m ${LSST_HOME}/stackvana_scons/ups/scons.table \
-    -r ${LSST_HOME}/stackvana_scons scons "stackvana_scons_${LSST_DM_TAG}"
+    -r ${LSST_HOME}/stackvana_scons scons "stackvana_scons_${LSST_TAG}"
 
 echo "
 # -*- python -*-
@@ -142,11 +142,11 @@ envPrepend(PATH, ${PRODUCT_DIR}/bin)
 eups declare \
     -m ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table \
     -L ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg \
-    -r ${LSST_HOME}/stackvana_sconsUtils sconsUtils "stackvana_sconsUtils_${LSST_DM_TAG}"
+    -r ${LSST_HOME}/stackvana_sconsUtils sconsUtils "stackvana_sconsUtils_${LSST_TAG}"
 
 
 ###################################################
 # 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
-echo "scons stackvana_scons_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap
-echo "sconsUtils stackvana_sconsUtils_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons stackvana_scons_${LSST_TAG}" >> ${EUPS_PATH}/site/manifest.remap
+echo "sconsUtils stackvana_sconsUtils_${LSST_TAG}" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -1,15 +1,16 @@
 # this script does the following
 # 1. Build up to sconsUtils
-# 2. Copy the full build to a special directory, ${LSST_HOME}/stackvana_sconsUtils
-# 3. Remove sconsUtils from eups
+# 2. Copy the full build to a special directory, ${LSST_HOME}/stackvana_scons(Utils)
+# 3. Remove scons(Utils) from eups
 # 4. Patch the copied version of sconsUtils
-# 5. Declare a new sconsUtils.
-# 6. Remap sconsUtils to the new one
+# 5. Declare a new scons(Utils).
+# 6. Remap scons(Utils) to the new one
 
 # this sequence of steps allows people to update their local eups install
 # more easily while retaining the conda integrations in sconsUtils
 
 SCONSUTILS_VERSION="18.1.0-3-g946de54"
+SCONS_VERSION="3.0.0.lsst1+5"
 
 
 ###################################################
@@ -69,11 +70,25 @@ fi
 mkdir -p ${LSST_HOME}/stackvana_sconsUtils
 cp -r ${sconsdir}/* ${LSST_HOME}/stackvana_sconsUtils/.
 
+if [[ `uname -s` == "Darwin" ]]; then
+    sconsdir="${LSST_HOME}/stack/miniconda/DarwinX86/scons/${SCONS_VERSION}"
+else
+    sconsdir="${LSST_HOME}/stack/miniconda/Linux64/scons/${SCONS_VERSION}"
+fi
+
+if [ ! -d ${sconsdir} ]; then
+    echo "scons version has changed! patches may need to be redone!"
+    exit 1
+fi
+
+mkdir -p ${LSST_HOME}/stackvana_scons
+cp -r ${sconsdir}/* ${LSST_HOME}/stackvana_scons/.
+
 
 ###################################################
 # 3. Remove sconsUtils from eups
 eups remove -v -t ${LSST_TAG} sconsUtils
-
+eups remove -v -t ${LSST_TAG} scons
 
 ###################################################
 # 4. Patch the copied version of sconsUtils
@@ -94,14 +109,19 @@ popd
 
 
 ###################################################
-# 5. Declare a new sconsUtils.
+# 5. Declare a new scons(Utils).
 eups declare \
     -m ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table \
     -L ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg \
     -r ${LSST_HOME}/stackvana_sconsUtils sconsUtils "${SCONSUTILS_VERSION}"
 
+eups declare \
+    -m ${LSST_HOME}/stackvana_scons/ups/scons.table \
+    -r ${LSST_HOME}/stackvana_scons scons "${SCONS_VERSION}"
+
 
 ###################################################
-# 6. Remap sconsUtils to the new one
+# 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
 echo "sconsUtils ${SCONSUTILS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons ${SCONS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -123,5 +123,5 @@ eups declare \
 ###################################################
 # 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
-echo "sconsUtils ${SCONSUTILS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
-echo "scons ${SCONS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
+echo "sconsUtils stackvana_${SCONSUTILS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons stackvana_${SCONS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -123,5 +123,5 @@ eups declare \
 ###################################################
 # 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
-echo "sconsUtils stackvana_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap
-echo "scons stackvana_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap
+echo "sconsUtils ${SCONSUTILS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons ${SCONS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -123,5 +123,5 @@ eups declare \
 ###################################################
 # 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
-echo "sconsUtils ${SCONSUTILS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
-echo "scons ${SCONS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
+echo "sconsUtils stackvana_sconsUtils" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons stackvana_scons" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -110,18 +110,43 @@ popd
 
 ###################################################
 # 5. Declare a new scons(Utils).
-eups declare \
-    -m ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table \
-    -L ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg \
-    -r ${LSST_HOME}/stackvana_sconsUtils sconsUtils "${SCONSUTILS_VERSION}"
+echo "
+setupRequired(python)
+envPrepend(PATH, ${PRODUCT_DIR}/bin)
+" > ${LSST_HOME}/stackvana_scons/ups/scons.table
 
 eups declare \
     -m ${LSST_HOME}/stackvana_scons/ups/scons.table \
-    -r ${LSST_HOME}/stackvana_scons scons "${SCONS_VERSION}"
+    -r ${LSST_HOME}/stackvana_scons scons "stackvana_scons_${LSST_DM_TAG}"
+
+echo "
+# -*- python -*-
+
+from lsst.sconsUtils import Configuration
+
+dependencies = {}
+
+config = Configuration(__file__, libs=[], hasSwigFiles=False)
+" > ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg
+
+echo "
+setupRequired(scons)
+setupRequired(pytest_flake8)
+setupRequired(pep8_naming)
+setupRequired(pytest_session2file)
+setupOptional(doxygen)
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
+envPrepend(PATH, ${PRODUCT_DIR}/bin)
+" > ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table
+
+eups declare \
+    -m ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.table \
+    -L ${LSST_HOME}/stackvana_sconsUtils/ups/sconsUtils.cfg \
+    -r ${LSST_HOME}/stackvana_sconsUtils sconsUtils "stackvana_sconsUtils_${LSST_DM_TAG}"
 
 
 ###################################################
 # 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
-echo "sconsUtils stackvana_sconsUtils" >> ${EUPS_PATH}/site/manifest.remap
-echo "scons stackvana_scons" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons stackvana_scons_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap
+echo "sconsUtils stackvana_sconsUtils_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/remaps/build_scons.sh
+++ b/recipe/remaps/build_scons.sh
@@ -123,5 +123,5 @@ eups declare \
 ###################################################
 # 6. Remap scons(Utils) to the new one
 mkdir -p ${EUPS_PATH}/site
-echo "sconsUtils stackvana_${SCONSUTILS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
-echo "scons stackvana_${SCONS_VERSION}" >> ${EUPS_PATH}/site/manifest.remap
+echo "sconsUtils stackvana_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap
+echo "scons stackvana_${LSST_DM_TAG}" >> ${EUPS_PATH}/site/manifest.remap

--- a/recipe/run_test_impl.sh
+++ b/recipe/run_test_impl.sh
@@ -36,7 +36,7 @@ eups list:"
 
 
 # this should work
-pkgs="doxygen boost fftw gsl log4cxx mpich sconsUtils starlink_ast coord xpa \
+pkgs="doxygen boost fftw gsl log4cxx mpich scons sconsUtils starlink_ast coord xpa \
 ndarray treecorr healpy python_psutil pep8_naming ws4py python_py python_execnet \
 pytest pytest_forked pytest_xdist python_coverage pytest_cov \
 pyflakes pycodestyle python_mccabe flake8 pytest_flake8 esutil requests mpi4py \

--- a/recipe/run_test_impl.sh
+++ b/recipe/run_test_impl.sh
@@ -121,3 +121,7 @@ else
     echo "failed!"
     exit 1
 fi
+
+# try an import
+setup pex_exceptions
+python -c "import lsst.pex.exceptions"


### PR DESCRIPTION
This PR puts in a few more remaps and isolates the build tooling from eups. This should let the core package be used to build most versions of the stack.

closes #42 
closes #50 
closes #51 
closes #11 